### PR TITLE
add: truthy for bool evaluation

### DIFF
--- a/sentinels/sentinels.py
+++ b/sentinels/sentinels.py
@@ -38,16 +38,21 @@ class Sentinel:
 
     *module_name*, if supplied, will be used instead of inspecting the call
     stack to find the name of the module from which
+
+    *truthy*, should be the value that is returned on Boolean evaluation.
+    if `None`, a `ValueError` is raised.
     """
     _name: str
     _repr: str
     _module_name: str
+    _truthy: str | None
 
     def __new__(
         cls,
         name: str,
         repr: str | None = None,
         module_name: str | None = None,
+        truthy: bool | None = None,
     ):
         name = str(name)
         repr = str(repr) if repr else f'<{name.split(".")[-1]}>'
@@ -71,8 +76,15 @@ class Sentinel:
         sentinel._name = name
         sentinel._repr = repr
         sentinel._module_name = module_name
+        sentinel._truthy = truthy
         with _lock:
             return _registry.setdefault(registry_key, sentinel)
+
+    def __bool__(self) -> bool:
+        if self._truthy is None:
+            raise ValueError(f"{self._name} is ambiguous.")
+        else:
+            return self._truthy
 
     def __repr__(self):
         return self._repr


### PR DESCRIPTION
As described in #12, Sentinels truthyness depends on the context of the sentinel.
This allows us to set what the sentinel can mean, and by default sentinels are ambiguous and forces the user to give it a meaning.

Example

```python

from sentinels import Sentinel

EOF = Sentinel('EOF')

# This will return a `ValueError` since EOF doesn't have a Boolean representation
# bool(EOF)
# However, we can compare a value with EOF and that does have a Boolean representation
line= read_line(file)
print(line is EOF)

Undefined = Sentinel('undefined', truthy=False)

bool(Undefined)
# >> False

Success = Sentinel('success', truthy=True)

bool(Success )
# >> True
```